### PR TITLE
인가처리 url 세팅

### DIFF
--- a/src/main/java/com/sparta/team2newsfeed/security/WebSecurityConfig.java
+++ b/src/main/java/com/sparta/team2newsfeed/security/WebSecurityConfig.java
@@ -46,7 +46,10 @@ public class WebSecurityConfig {
         http.authorizeHttpRequests((authorizeHttpRequests) ->
                 authorizeHttpRequests
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll() // resources 접근 허용 설정
+                        .requestMatchers("/api/user/userupdate").authenticated()
                         .requestMatchers("/api/user/**").permitAll() // '/api/users/'로 시작하는 요청 모두 접근 허가
+                        .requestMatchers("/api/boardmake/**").authenticated()
+                        .requestMatchers("/api/board/**").permitAll()
                         .anyRequest().authenticated() // 그 외 모든 요청 인증처리
         );
 


### PR DESCRIPTION
인가처리 url 세팅
api를 생성, 수정, 제거는 /api/boardmake/** 경로
로그인이 필요없는 탐색계열 경로는 /api/board/** 경로로 수정하였습니다.