### PR TITLE
fix: cooklevel, category 정규식 검증 및 BoardController URL 수정

### DIFF
--- a/src/main/java/com/sparta/team2newsfeed/controller/BoardController.java
+++ b/src/main/java/com/sparta/team2newsfeed/controller/BoardController.java
@@ -1,18 +1,15 @@
 package com.sparta.team2newsfeed.controller;
 
 import com.sparta.team2newsfeed.dto.BoardRequestDto;
-import com.sparta.team2newsfeed.dto.BoardResponseDto;
 import com.sparta.team2newsfeed.imp.UserDetailsImpl;
 import com.sparta.team2newsfeed.service.BoardService;
-import org.springframework.http.HttpStatus;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.concurrent.RejectedExecutionException;
-
 @RestController
-@RequestMapping("/api/board")
+@RequestMapping("/api")
 public class BoardController {
     //Service 주입
     private final BoardService boardService;
@@ -28,44 +25,44 @@ public class BoardController {
     }
 
     //단일게시글 조회
-    @GetMapping("/{boardId}")
+    @GetMapping("/board/{boardId}")
     public ResponseEntity<?> getBoardOne(@PathVariable Long boardId) {
         return boardService.getBoardOne(boardId);
     }
 
     //카테고리별 조회
-    @GetMapping("/category/{categoryName}")
+    @GetMapping("/board/category/{categoryName}")
     public ResponseEntity<?> getBoardCategory(@PathVariable String categoryName) {
         return boardService.getBoardCategory(categoryName);
     }
 
     //난이도별 조회
-    @GetMapping("/cooklevel/{cookLevel}")
+    @GetMapping("/board/cooklevel/{cookLevel}")
     public ResponseEntity<?> getBoardCookLevel(@PathVariable int cookLevel) {
         return boardService.getBoardCookLevel(cookLevel);
     }
 
     //게시글 작성
-    @PostMapping
+    @PostMapping("/boardmake")
     public ResponseEntity<?> addBoard(@AuthenticationPrincipal UserDetailsImpl userDetails,
-                                      @RequestBody BoardRequestDto boardRequestDto
+                                      @Valid @RequestBody BoardRequestDto boardRequestDto
                                       ) {
         return boardService.addBoard(userDetails, boardRequestDto);
 
     }
 
     //게시글 수정
-    @PutMapping("/{boardId}")
+    @PutMapping("/boardmake/{boardId}")
     public ResponseEntity<?> updateBoard(@PathVariable Long boardId,
                                          @AuthenticationPrincipal UserDetailsImpl userDetails,
-                                         @RequestBody BoardRequestDto boardRequestDto
+                                        @Valid @RequestBody BoardRequestDto boardRequestDto
     ) {
         return boardService.updateBoard(boardId, userDetails, boardRequestDto);
     }
 
 
     //게시글 삭제
-    @DeleteMapping("/{boardId}")
+    @DeleteMapping("/boardmake/{boardId}")
     public ResponseEntity<?> deleteBoard(@PathVariable Long boardId,
                                          @AuthenticationPrincipal UserDetailsImpl userDetails
     ) {

--- a/src/main/java/com/sparta/team2newsfeed/dto/BoardRequestDto.java
+++ b/src/main/java/com/sparta/team2newsfeed/dto/BoardRequestDto.java
@@ -1,6 +1,7 @@
 package com.sparta.team2newsfeed.dto;
 
 import com.sparta.team2newsfeed.entity.User;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 
 @Getter
@@ -11,9 +12,11 @@ public class BoardRequestDto {
 
     private String body;
 
+    @Pattern(regexp = "^(KOREAN|CHINESE|JAPANESE|WESTERN)$")
     private String category;
 
-    private int cookLevel;
+    @Pattern(regexp = "^[12345]$")
+    private String cookLevel;
 
     private User user;
 }

--- a/src/main/java/com/sparta/team2newsfeed/entity/Board.java
+++ b/src/main/java/com/sparta/team2newsfeed/entity/Board.java
@@ -36,7 +36,7 @@ public class Board extends Timestemped {
         this.title = boardRequestDto.getTitle();
         this.body = boardRequestDto.getBody();
         this.category = boardRequestDto.getCategory();
-        this.cookLevel = boardRequestDto.getCookLevel();
+        this.cookLevel = Integer.parseInt(boardRequestDto.getCookLevel());
         this.user = user;
     }
 
@@ -44,6 +44,6 @@ public class Board extends Timestemped {
         this.title = boardRequestDto.getTitle();
         this.body = boardRequestDto.getBody();
         this.category = boardRequestDto.getCategory();
-        this.cookLevel = boardRequestDto.getCookLevel();
+        this.cookLevel = Integer.parseInt(boardRequestDto.getCookLevel());
     }
 }


### PR DESCRIPTION
1. board 생성 수정 삭제 경로 변경 (board -> boardmaker)
2. category와 cooklevel 조건 걸기위해 정규식생성
3. 정규식생성으로 cooklevel을 String타입으로 받은 뒤 생성할때 int로 변환처리