### PR TITLE
유저 정보 수정시 비밀번호를 변경하지 않아도되도록 수정

### DIFF
--- a/src/main/java/com/sparta/team2newsfeed/service/UserService.java
+++ b/src/main/java/com/sparta/team2newsfeed/service/UserService.java
@@ -66,8 +66,11 @@ public class UserService {
         if(!passwordEncoder.matches(userUpdateRequestDto.getNowPassword(),user.getPassword())){
             throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
         }
-        if(!userUpdateRequestDto.getNewPassword().equals(userUpdateRequestDto.getNewCheckPassword())){
-            throw new IllegalArgumentException("변경하는 비밀번호가 일치하지 않습니다.");
+        if(userUpdateRequestDto.getNewPassword() != null)
+        {
+            if(!userUpdateRequestDto.getNewPassword().equals(userUpdateRequestDto.getNewCheckPassword())){
+                throw new IllegalArgumentException("변경하는 비밀번호가 일치하지 않습니다.");
+            }
         }
         if (userRepository.findByUsername(userUpdateRequestDto.getUsername()).isPresent()) {
             throw new IllegalArgumentException("이미 존재하는 유저 입니다.");


### PR DESCRIPTION
기존은 유저정보 수정시 비밀번호 변경칸이 공란이면 에러가 발생하였음
유저 정보 수정시 비밀번호 변경칸이 공란이어도 문제없이 돌아가도록 수정